### PR TITLE
Try hacky light mode with css invert filter

### DIFF
--- a/src/assets/scss/Global/app-grid.scss
+++ b/src/assets/scss/Global/app-grid.scss
@@ -9,10 +9,10 @@
     "l-sidebar content tabs";
   align-content: center;
   max-width: 2720px;
-  height: calc(100vh - 1rem);
+  height: 100vh;
   margin: 0 auto;
   gap: 1rem;
-  margin: $small;
+  padding: $small;
 }
 
 #acontent {

--- a/src/assets/scss/Global/basic.scss
+++ b/src/assets/scss/Global/basic.scss
@@ -50,6 +50,11 @@ a {
   color: #fff;
 }
 
+::selection {
+  background: $blue;
+  color: $white;
+}
+
 button {
   border: none;
   font-size: 0.9rem !important;
@@ -64,6 +69,11 @@ button {
   &:hover {
     background-image: linear-gradient(70deg, #234ece, $darkblue);
   }
+}
+
+img {
+  pointer-events: none;
+  user-select: none;
 }
 
 .btn-active {

--- a/src/assets/scss/Global/index.scss
+++ b/src/assets/scss/Global/index.scss
@@ -1,5 +1,6 @@
 @import "./app-grid.scss", "./controls.scss", "./inputs.scss",
-  "./scrollbars.scss", "./state.scss", "./variants.scss", "./basic.scss";
+  "./scrollbars.scss", "./state.scss", "./variants.scss", "./basic.scss",
+  "./light-mode.scss";
 
 :root {
   --separator: #ffffff46;
@@ -12,12 +13,15 @@
 
 body {
   margin: 0;
-  background-color: $body;
   color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  font-family: "SF Compact Display" !important;
+  font-family: "SF Compact Display";
   font-size: 1rem;
   overflow: hidden;
   image-rendering: -webkit-optimize-contrast;
+}
+
+#app {
+  background-color: $body;
 }

--- a/src/assets/scss/Global/light-mode.scss
+++ b/src/assets/scss/Global/light-mode.scss
@@ -1,0 +1,47 @@
+$invertcontextblue: #dcb131;
+
+#app {
+  filter: invert(100%);
+
+  ::selection {
+    background: $invertblue;
+    color: $black;
+  }
+
+  img {
+    filter: invert(100%);
+  }
+
+  .context-menu {
+    background-color: $black;
+    color: $white;
+
+    .children {
+      background-color: $black;
+    }
+
+    .context-item {
+      color: $white;
+
+      &:hover {
+        background-color: $invertcontextblue;
+        color: $black;
+      }
+    }
+  }
+
+  background-color: $light;
+}
+
+.force-lm {
+  filter: invert(0%) !important;
+}
+
+.ignore-lm {
+  filter: invert(100%) !important;
+
+  ::selection {
+    background: $blue !important;
+    color: $white !important;
+  }
+}

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1,6 +1,7 @@
 // colors
 
 $body: #0f1218;
+$light: #999999;
 $separator: #ffffff2f;
 $highlight-blue: #006eff;
 $bbb: #161616; //bottom controls background
@@ -28,6 +29,7 @@ $gray5: rgb(44, 44, 46);
 
 $red: #ff453a;
 $blue: #0a84ff;
+$invertblue: #f57b00;
 $darkblue: #055ee2;
 $green: rgb(20, 160, 55);
 $yellow: rgb(255, 214, 10);

--- a/src/components/AlbumView/Header.vue
+++ b/src/components/AlbumView/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="a-header rounded"
+    class="a-header rounded ignore-lm"
     ref="albumheaderthing"
     :style="{
       backgroundImage: `linear-gradient(

--- a/src/components/Logo.vue
+++ b/src/components/Logo.vue
@@ -1,24 +1,20 @@
 <template>
-  <div id="logo-container"
-  >
+  <div class="app-logo">
     <router-link :to="{ name: 'Home' }">
-      <div id="logo" class="rounded"></div
-    ></router-link>
+      <img
+        class="app-logo rounded shadow-sm"
+        src="../assets/images/logo.webp"
+        alt="logo"
+      />
+    </router-link>
   </div>
 </template>
 
 <style lang="scss">
-@import "../assets/scss/mixins.scss";
-
-#logo-container {
-  overflow: hidden;
-}
-
-#logo {
-  height: 4.5rem !important;
+.app-logo {
+  height: 5rem !important;
   width: 15rem;
-  background-image: url(./../assets/images/logo.webp);
-  background-size: contain;
-  @include ximage;
+  object-fit: cover;
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
The CSS color invert filter provides a simple way to handle light mode. Since the app is dark mode first, everything is designed to be dark mode, then we add patches for light mode. This is by adding ignore-invert classes, darkening excessively light areas, etc.

There are downside of this: 
- `emojis get inverted too ... sweet!`
- `you have to invert colors to use them`
- `all kinds of contrast issues`


---
**Worked on components**
- [ ] Right sidebar (including search)
- [ ] Navigation
- [ ] Folder page
- [ ]  Playlist page
- [ ] Album page

---
# ⚠️ I'm no longer working on this
There are too many issues that come with this hacky system. So, I'm dropping it until i find a way to handle the emoji issue.