### PR TITLE
Add playlist reorder endpoint

### DIFF
--- a/swingmusic/api/playlist.py
+++ b/swingmusic/api/playlist.py
@@ -167,6 +167,30 @@ class AddItemToPlaylistBody(BaseModel):
     )
     itemhash: str = Field(..., description="The hash of the item to add")
 
+class ReorderPlaylistBody(BaseModel):
+    trackhashes: list[str] = Field(
+        ...,
+        description="A list of track hashes in the new order",
+        example=["trackhash1", "trackhash2", "trackhash3"],
+    )
+
+@api.post("/<playlistid>/reorder")
+def reorder_playlist(path: PlaylistIDPath, body: ReorderPlaylistBody):
+    """
+    Reorder playlist.
+
+    The body should be a list of track hashes in the new order.
+    """
+    playlist_id = path.playlistid
+    trackhashes = body.trackhashes
+
+    print(f"Reordering playlist {playlist_id} with track hashes: {trackhashes}")
+
+    if not isinstance(trackhashes, list):
+        return {"error": "Invalid request body"}, 400
+
+    PlaylistTable.reorder_playlist(int(playlist_id), trackhashes)
+    return {"msg": "Done"}, 200
 
 @api.post("/<playlistid>/add")
 def add_item_to_playlist(path: PlaylistIDPath, body: AddItemToPlaylistBody):

--- a/swingmusic/db/userdata.py
+++ b/swingmusic/db/userdata.py
@@ -414,6 +414,17 @@ class PlaylistTable(Base):
             yield playlist_to_dataclass(i)
 
     @classmethod
+    def reorder_playlist(cls, id: int, trackhashes: list[str]):
+        return next(
+            cls.execute(
+                update(cls)
+                .where((cls.id == id) & (cls.userid == get_current_userid()))
+                .values(trackhashes=trackhashes),
+                commit=True,
+            )
+        )
+
+    @classmethod
     def add_one(cls, playlist: dict[str, Any]):
         playlist["userid"] = get_current_userid()
         result = cls.insert_one(playlist)

--- a/swingmusic/models/track.py
+++ b/swingmusic/models/track.py
@@ -54,6 +54,8 @@ class Track:
     explicit: bool = False
     fav_userids: list[int] = field(default_factory=list)
 
+    album1: str = ""
+
     @property
     def is_favorite(self):
         return get_current_userid() in self.fav_userids
@@ -82,6 +84,7 @@ class Track:
         """
         self.og_title = self.title
         self.og_album = self.album
+        self.album1 = self.album
         self.folder = self.folder + "/"
         self.weakhash = create_hash(self.title, self.artists)
 
@@ -221,7 +224,7 @@ class Track:
         Recreates the trackhash based on the current title, album, and artist information.
         """
         self.trackhash = create_hash(
-            self.title, self.album, *(artist["name"] for artist in self.artists)
+            self.title, self.album1, *(artist["name"] for artist in self.artists)
         )
 
     def copy(self):


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- Added an endpoint to the api to allow clients to reorder playlist tracks. (Requested in issue #317 )
- Fixed an issue where tracks would not appear in albums if they appeared in a different album version (this could be improved further)