### PR TITLE
Remove cli arg from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir --find-links=wheels/ swingmusic
 Run rm -rf /app/swingmusic/wheels
 
-ENTRYPOINT ["python", "-m", "swingmusic", "--host", "0.0.0.0", "--config", "/config", "--client", "/config/client"]
+ENTRYPOINT ["python", "-m", "swingmusic", "--host", "0.0.0.0", "--config", "/config"]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The docker build stores the client in the default location.
The client path to not need to be provided separately .