### PR TITLE
Debug mode to logging

### DIFF
--- a/src/swingmusic/logger.py
+++ b/src/swingmusic/logger.py
@@ -116,8 +116,7 @@ class CustomFormatter(logging.Formatter):
         return super().format(record)
 
     def formatException(self, e):
-        # do not print on cli only in file.
-        # TODO: inform user that non terminal exception happened?
+        # Only print to cli if in debug mode
         if "debug" in sys.argv:
             return super().formatException(e)
         else:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Add debug mode to logging.

If swingmusic is launched in debug mode (`--debug`) stack traces are print directly on terminal.
On all other instances stack traces are not printed on terminal