### PR TITLE
Downgrade binary build environment for Linux. Fixes #422

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,8 +245,8 @@ jobs:
       matrix:
         os:
           [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
             windows-latest,
             windows-11-arm,
             macos-13,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Binaries are built using `ubuntu-22.04[-arm]` images (instead of `-latest`), hence providing compatibility with Debian 12.

Sample release [here](https://github.com/orhtej2/swingmusic/releases/tag/v2.1.3), action that produced it [here](https://github.com/orhtej2/swingmusic/actions/runs/20065321410), not apples-to-apples comparison as I reused artifacts from 2.1.3 but the resulting binary was runnable on my machine (TM).