### PR TITLE
fix: albums from 1970 using last modified date instead of album release date

### DIFF
--- a/src/swingmusic/lib/taglib.py
+++ b/src/swingmusic/lib/taglib.py
@@ -182,6 +182,10 @@ def get_tags(filepath: str, config: UserConfig) -> dict:
     else:
         other = {}
 
+    date = parse_date(tags.year or "")
+    if date is None:
+        date = int(last_mod)
+
     metadata: dict[str, Any] = {
         "album": tags.album,
         "albumartists": tags.albumartist,
@@ -197,7 +201,7 @@ def get_tags(filepath: str, config: UserConfig) -> dict:
         "genres": tags.genre,
         "copyright": " ".join(other.get("copyright", [])), # INFO: Extract copyright from extra data
         "extra": {},
-        "date": parse_date(tags.year or "") or int(last_mod)
+        "date": date
     }
 
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

```python
"date": parse_date(tags.year or "") or int(last_mod)
```

If album year set to 1970 a timestamp value is zero, and result of `parse_date` function treated as false and `last_mod` value applied. I fixed it comparing the result of `parse_date` with None value. 