### PR TITLE
fix: different tracks with the same title, excluding special characters, were deduplicated from the album

### DIFF
--- a/src/swingmusic/lib/taglib.py
+++ b/src/swingmusic/lib/taglib.py
@@ -277,9 +277,11 @@ def get_tags(filepath: str, config: UserConfig) -> dict:
     )
 
     metadata["trackhash"] = create_hash(
-        metadata.get("artists", ""),
-        metadata.get("album", ""),
         metadata.get("title", ""),
+        metadata.get("album", ""),
+        *split_artists(metadata.get("artists", ""), config),
+        str(metadata.get("track", "")),
+        str(metadata.get("disc", "")),
     )
 
 

--- a/src/swingmusic/models/track.py
+++ b/src/swingmusic/models/track.py
@@ -221,7 +221,8 @@ class Track:
         Recreates the trackhash based on the current title, album, and artist information.
         """
         self.trackhash = create_hash(
-            self.title, self.album, *(artist["name"] for artist in self.artists)
+            self.title, self.album, *(artist["name"] for artist in self.artists),
+            str(self.track), str(self.disc),
         )
 
     def copy(self):


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I have an album in my library the contents of which look like this:

```
.
└── Pink Floyd - The Wall (Remastered 2011 Version) (1979) [24B-96kHz]
    ├── cover.jpg
    ├── Disc 1
    │   ├── 01. In the Flesh?.flac
    │   ├── 02. The Thin Ice.flac
    │   ├── 03. Another Brick in the Wall, Pt. 1.flac
    │   ├── 04. The Happiest Days of Our Lives.flac
    │   ├── 05. Another Brick in the Wall, Pt. 2.flac
    │   ├── 06. Mother.flac
    │   ├── 07. Goodbye Blue Sky.flac
    │   ├── 08. Empty Spaces.flac
    │   ├── 09. Young Lust.flac
    │   ├── 10. One of My Turns.flac
    │   ├── 11. Don't Leave Me Now.flac
    │   ├── 12. Another Brick in the Wall, Pt. 3.flac
    │   └── 13. Goodbye Cruel World.flac
    └── Disc 2
        ├── 01. Hey You.flac
        ├── 02. Is There Anybody Out There.flac
        ├── 03. Nobody Home.flac
        ├── 04. Vera.flac
        ├── 05. Bring the Boys Back Home.flac
        ├── 06. Comfortably Numb.flac
        ├── 07. The Show Must Go On.flac
        ├── 08. In the Flesh.flac
        ├── 09. Run Like Hell.flac
        ├── 10. Waiting for the Worms.flac
        ├── 11. Stop.flac
        ├── 12. The Trial.flac
        └── 13. Outside the Wall.flac
 ```

There are two tracks, `01. In the Flesh?` on Disc 1 and `08. In the Flesh` on Disc 2. However, in SwingMusic only the second track appears:

<img width="1333" height="688" alt="image" src="https://github.com/user-attachments/assets/6343da28-4614-4044-b177-a57e17198815" />
<img width="1343" height="691" alt="image" src="https://github.com/user-attachments/assets/e2e55f85-8a39-4fe8-9651-ffca39f47d37" />

As I discovered, this happens because the track hashes are identical for both tracks, even though the songs are different. The reason is that the [hashing](https://github.com/swingmx/swingmusic/blob/e9a4c1e11a1e1336e27ef8124c98af8f3b4ddf07/src/swingmusic/utils/hashing.py#L28C20-L28C36) function ignores non-alphanumeric characters in the title, which generally makes sense but causes a bug in albums like this.

In this case, it might be enough to track only the track number, but in the worst-case scenario there may be albums where songs share the same track numbers across different discs, so I think it makes sense to include the disc number in the hash as well.