### PR TITLE
Fix: AttributeError 'Paths' has no attribute 'get_plugins_path' in lastfm plugin

### DIFF
--- a/src/swingmusic/plugins/lastfm.py
+++ b/src/swingmusic/plugins/lastfm.py
@@ -145,7 +145,7 @@ class LastFmPlugin(Plugin):
             return
 
         self.UPLOADING_DUMPS = True
-        dump_dir = Paths.get_plugins_path() / "lastfm"
+        dump_dir = Paths().plugins_path / "lastfm"
 
         if not dump_dir.exists():
             return


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**

Each time a scrobble happened, this error appeared in the logs:

```
Exception in thread Thread-15 (scrobble):
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.11/site-packages/swingmusic/plugins/lastfm.py", line 89, in scrobble
    self.upload_dumps()
  File "/usr/local/lib/python3.11/site-packages/swingmusic/plugins/lastfm.py", line 148, in upload_dumps
    dump_dir = Paths.get_plugins_path() / "lastfm"
               ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'Paths' has no attribute 'get_plugins_path'. Did you mean: 'plugins_path'?
```

So here is the fix 