### PR TITLE
Fix: list index out of range when trying to unset admin role

### DIFF
--- a/src/swingmusic/api/auth.py
+++ b/src/swingmusic/api/auth.py
@@ -173,7 +173,7 @@ def update_profile(body: UpdateProfileBody):
         if "admin" not in current_user["roles"]:
             return {"msg": "Only admins can update roles"}, 403
 
-        all_users = UserTable.get_all()
+        all_users = list(UserTable.get_all())
         if "admin" not in body.roles:
             # check if we're removing the last admin
             admins = [user for user in all_users if "admin" in user.roles]
@@ -186,14 +186,17 @@ def update_profile(body: UpdateProfileBody):
         if "guest" in _user.roles:
             return {"msg": "Cannot update guest user"}, 400
 
-        # finally, convert roles to json string
-        user["roles"] = body.roles
-
     if user["password"]:
         user["password"] = hash_password(user["password"])
 
     # remove empty values
     clean_user = {k: v for k, v in user.items() if v}
+
+    # finally, convert roles to json string
+    # doing it here to prevent deleting roles from clean user 
+    # when body.roles is an empty list
+    if body.roles is not None:
+        clean_user["roles"] = body.roles
 
     try:
         # return authdb.update_user(clean_user)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**

When I tried to turn off admin on user in web UI server falls with 500:

```
ERROR: Exception on /auth/profile/update [PUT]
Time: 2025-12-15 00:48:02 UTC
Logger: swingmusic.app_builder
Location: app.py:875 (log_exception)

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()

  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)

  File "/usr/local/lib/python3.11/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))

  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()

  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)

  File "/usr/local/lib/python3.11/site-packages/flask_openapi3/scaffold.py", line 117, in view_func
    response = func(**func_kwargs)

  File "/usr/local/lib/python3.11/site-packages/swingmusic/api/auth.py", line 185, in update_profile
    _user = [u for u in all_users if u.id == user["id"]][0]

IndexError: list index out of range
```

here is code snippet:

```python
      all_users = UserTable.get_all()
      if "admin" not in body.roles:
          # check if we're removing the last admin
          admins = [user for user in all_users if "admin" in user.roles]

          if len(admins) == 1 and admins[0].id == user["id"]:
              return {"msg": "Cannot remove the only admin"}, 400

      # guest roles cannot be updated
      _user = [u for u in all_users if u.id == user["id"]][0]
      if "guest" in _user.roles:
          return {"msg": "Cannot update guest user"}, 400
```

After check if we're removing the last admin the iterible `all_users` was already used and when trying to get `_user`, `all_user` is practically empty list. Must convert it to `list` to reuse.

Also `clean_user = {k: v for k, v in user.items() if v}` filters out `roles` if it is empty list, it is when you try to unset admin role. So I apply roles after fields filtering. 