### PR TITLE
fix #440: move freeze_support to top of run.py to fix Windows crash

### DIFF
--- a/run.py
+++ b/run.py
@@ -6,6 +6,10 @@ from pathlib import Path
 import swingmusic.__main__ as app
 
 if __name__ == "__main__":
+	# Fixed: freeze_support() must be called immediately to prevent 
+	# recursive process spawning and ArgumentParser errors on Windows EXE.
+    multiprocessing.freeze_support()
+    
     # this entry should only be used by pyinstaller.
     # add freeze support here as pyinstaller uses this entry
 
@@ -20,5 +24,4 @@ if __name__ == "__main__":
         sys.argv.extend(["--client", client_str])
         sys.orig_argv.extend(["--client", client_str])
 
-    multiprocessing.freeze_support()
     app.run()


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR fixes the `ValueError: not enough values to unpack` crash (issue #440) on Windows when scanning the library in the compiled (.exe) version.

Tested on Windows 11
<img width="468" height="526" alt="Screenshot_2" src="https://github.com/user-attachments/assets/5f57a176-af38-4088-91f6-77a52a094dc3" />
